### PR TITLE
feat: runtime permission mode switching and auto mode

### DIFF
--- a/src/main/ipc-handlers.ts
+++ b/src/main/ipc-handlers.ts
@@ -684,6 +684,11 @@ export function registerIpcHandlers(deps: IpcHandlerDeps): { cleanup: () => void
     return settings.getPermissionMode();
   });
 
+  ipcMain.handle('settings:setPermissionMode', async (_event, mode: PermissionMode) => {
+    state.permissionMode = mode;
+    await settings.setPermissionMode(mode);
+  });
+
   // ---- Hook Config ----
   ipcMain.handle('hookConfig:load', async (_event, projectId?: string) => {
     const project = projectId ? state.projectManager?.getProject(projectId) : undefined;

--- a/src/preload.ts
+++ b/src/preload.ts
@@ -75,6 +75,8 @@ const api = {
     ipcRenderer.invoke('settings:removeRecentDir', dir),
   getPermissionMode: (): Promise<PermissionMode> =>
     ipcRenderer.invoke('settings:permissionMode'),
+  setPermissionMode: (mode: PermissionMode): Promise<void> =>
+    ipcRenderer.invoke('settings:setPermissionMode', mode),
 
   // Hook config
   getHookConfig: (projectId?: string): Promise<RepoHookConfig> =>

--- a/src/renderer/App.tsx
+++ b/src/renderer/App.tsx
@@ -60,6 +60,7 @@ export default function App() {
   );
   const [hookStatus, setHookStatus] = useState<{ hookName: string; status: 'running' | 'done' | 'failed'; error?: string } | null>(null);
   const hookDismissTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const [permissionMode, setPermissionMode] = useState<PermissionMode>('bypassPermissions');
   const [worktreeCloseConfirm, setWorktreeCloseConfirm] = useState<{
     tabId: string; worktreeName: string; clean: boolean; changesCount: number;
   } | null>(null);
@@ -270,6 +271,7 @@ export default function App() {
 
       const savedMode = await window.claudeTerminal.getPermissionMode();
       if (cancelled) return;
+      setPermissionMode(savedMode);
 
       const result = await window.claudeTerminal.startSession(cliDir, savedMode);
       if (cancelled) return;
@@ -473,6 +475,7 @@ export default function App() {
   }, [appState, handleAddProject, handleNewTabWithoutWorktree, handleNewShellTab, handleSelectTab, handleSelectProject, handleCloseTab, tryShowWorktreeDialog]);
 
   const handleStartSession = useCallback(async (dir: string, mode: PermissionMode) => {
+    setPermissionMode(mode);
     const result = await window.claudeTerminal.startSession(dir, mode);
     setWorkspaceDir(dir);
 
@@ -505,6 +508,11 @@ export default function App() {
       const tab = await window.claudeTerminal.createTab(projectId, null);
       setActiveTabId(tab.id);
     }
+  }, []);
+
+  const handlePermissionModeChange = useCallback((mode: PermissionMode) => {
+    setPermissionMode(mode);
+    window.claudeTerminal.setPermissionMode(mode);
   }, []);
 
   if (appState === 'startup') {
@@ -560,7 +568,7 @@ export default function App() {
             />
           ))}
         </div>
-        <StatusBar tabs={activeProjectTabs} hookStatus={hookStatus} />
+        <StatusBar tabs={activeProjectTabs} hookStatus={hookStatus} permissionMode={permissionMode} onPermissionModeChange={handlePermissionModeChange} />
       </div>
       {showWorktreeDialog && (
         <WorktreeNameDialog

--- a/src/renderer/components/StartupDialog.tsx
+++ b/src/renderer/components/StartupDialog.tsx
@@ -15,6 +15,7 @@ interface StartupDialogProps {
 
 const PERMISSION_OPTIONS: { value: PermissionMode; label: string }[] = [
   { value: 'bypassPermissions', label: 'Bypass' },
+  { value: 'auto', label: 'Auto' },
   { value: 'acceptEdits', label: 'Accept Edits' },
   { value: 'plan', label: 'Plan Mode' },
   { value: 'default', label: 'Default' },

--- a/src/renderer/components/StatusBar.tsx
+++ b/src/renderer/components/StatusBar.tsx
@@ -1,6 +1,6 @@
-import React from 'react';
+import React, { useCallback } from 'react';
 import { cn } from '@/lib/utils';
-import type { Tab, TabStatus } from '../../shared/types';
+import type { Tab, TabStatus, PermissionMode } from '../../shared/types';
 import { useShellOptions } from '../shell-context';
 import TabIndicator from './TabIndicator';
 
@@ -23,12 +23,26 @@ const hookColorMap: Record<string, string> = {
   failed: 'text-destructive',
 };
 
+const PERMISSION_MODE_ORDER: PermissionMode[] = [
+  'bypassPermissions', 'auto', 'acceptEdits', 'plan', 'default',
+];
+
+const PERMISSION_MODE_LABELS: Record<PermissionMode, string> = {
+  bypassPermissions: 'Bypass',
+  auto: 'Auto',
+  acceptEdits: 'Accept Edits',
+  plan: 'Plan',
+  default: 'Default',
+};
+
 interface StatusBarProps {
   tabs: Tab[];
   hookStatus?: { hookName: string; status: 'running' | 'done' | 'failed'; error?: string } | null;
+  permissionMode: PermissionMode;
+  onPermissionModeChange: (mode: PermissionMode) => void;
 }
 
-const StatusBar = React.memo(function StatusBar({ tabs, hookStatus }: StatusBarProps) {
+const StatusBar = React.memo(function StatusBar({ tabs, hookStatus, permissionMode, onPermissionModeChange }: StatusBarProps) {
   const shellOptions = useShellOptions();
   const isWindows = window.claudeTerminal?.platform === 'win32';
   const shellHint = shellOptions.length >= 2 && isWindows
@@ -40,6 +54,12 @@ const StatusBar = React.memo(function StatusBar({ tabs, hookStatus }: StatusBarP
   for (const tab of tabs) {
     counts.set(tab.status, (counts.get(tab.status) ?? 0) + 1);
   }
+
+  const cyclePermissionMode = useCallback(() => {
+    const idx = PERMISSION_MODE_ORDER.indexOf(permissionMode);
+    const next = PERMISSION_MODE_ORDER[(idx + 1) % PERMISSION_MODE_ORDER.length];
+    onPermissionModeChange(next);
+  }, [permissionMode, onPermissionModeChange]);
 
   return (
     <div className="flex gap-4 px-3 py-0.5 bg-[hsl(var(--project-hue)_30%_18%)] text-muted-foreground text-xs min-h-[22px] items-center border-t border-border">
@@ -60,6 +80,13 @@ const StatusBar = React.memo(function StatusBar({ tabs, hookStatus }: StatusBarP
           {' '}{hookStatus.hookName}{hookStatus.status === 'running' ? '...' : ''}
         </span>
       )}
+      <button
+        onClick={cyclePermissionMode}
+        className="text-xs text-muted-foreground hover:text-foreground transition-colors cursor-pointer bg-transparent border-none p-0"
+        title={`Permission mode: ${PERMISSION_MODE_LABELS[permissionMode]} (click to cycle — affects new tabs only)`}
+      >
+        Mode: {PERMISSION_MODE_LABELS[permissionMode]}
+      </button>
       <span className="ml-auto overflow-hidden whitespace-nowrap text-ellipsis min-w-0">
         Ctrl+T Claude | Ctrl+W Worktree | Ctrl+P Projects{shellHint ? ` | ${shellHint}` : ''} | Ctrl+F4 close | Ctrl+Tab switch | F2 rename
       </span>

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -2,7 +2,7 @@ export type TabStatus = 'new' | 'working' | 'idle' | 'requires_response' | 'shel
 
 export type TabType = 'claude' | 'shell';
 
-export type PermissionMode = 'default' | 'plan' | 'acceptEdits' | 'bypassPermissions';
+export type PermissionMode = 'default' | 'auto' | 'plan' | 'acceptEdits' | 'bypassPermissions';
 
 export interface Tab {
   id: string;
@@ -69,6 +69,7 @@ export interface WorkspaceConfig {
 
 export const PERMISSION_FLAGS: Record<PermissionMode, string[]> = {
   default: [],
+  auto: ['--enable-auto-mode'],
   plan: ['--plan'],
   acceptEdits: ['--allowedTools', 'Edit,Write,NotebookEdit'],
   bypassPermissions: ['--dangerously-skip-permissions'],

--- a/src/web-client/ws-bridge.ts
+++ b/src/web-client/ws-bridge.ts
@@ -313,6 +313,7 @@ export class WebSocketBridge {
       getRecentDirs: async (): Promise<string[]> => [],
       removeRecentDir: async (): Promise<void> => {},
       getPermissionMode: async () => 'default' as const,
+      setPermissionMode: async (): Promise<void> => {},
 
       // Hook config (stubs — not available remotely)
       getHookConfig: async () => ({ hooks: {} }),


### PR DESCRIPTION
## Summary
- Add clickable permission mode indicator in the status bar — click to cycle through Bypass → Auto → Accept Edits → Plan → Default
- Add new Claude Code "auto" permission mode (`--enable-auto-mode` flag)
- Mode changes persist to settings and affect new tabs only

## Test plan
- [ ] Start app, verify "Mode: Bypass" appears in status bar
- [ ] Click the mode indicator, verify it cycles through all 5 modes
- [ ] Open a new tab after changing mode, verify the correct CLI flag is passed
- [ ] Verify startup dialog also shows the new "Auto" option

🤖 Generated with [Claude Code](https://claude.com/claude-code)