### PR TITLE
feat: settings dialog with default terminal shortcut

### DIFF
--- a/src/main/ipc-handlers.ts
+++ b/src/main/ipc-handlers.ts
@@ -684,6 +684,14 @@ export function registerIpcHandlers(deps: IpcHandlerDeps): { cleanup: () => void
     return settings.getPermissionMode();
   });
 
+  ipcMain.handle('settings:getDefaultShell', async () => {
+    return settings.getDefaultShell();
+  });
+
+  ipcMain.handle('settings:setDefaultShell', async (_event, shellId: string | null) => {
+    await settings.setDefaultShell(shellId);
+  });
+
   // ---- Hook Config ----
   ipcMain.handle('hookConfig:load', async (_event, projectId?: string) => {
     const project = projectId ? state.projectManager?.getProject(projectId) : undefined;

--- a/src/main/settings-store.ts
+++ b/src/main/settings-store.ts
@@ -12,11 +12,13 @@ const SESSIONS_FILE = 'sessions.json';
 interface StoreData {
   recentDirs: string[];
   permissionMode: PermissionMode;
+  defaultShell: string | null;
 }
 
 const DEFAULTS: StoreData = {
   recentDirs: [],
   permissionMode: 'bypassPermissions',
+  defaultShell: null,
 };
 
 export class SettingsStore {
@@ -66,6 +68,15 @@ export class SettingsStore {
 
   async setPermissionMode(mode: PermissionMode): Promise<void> {
     this.data.permissionMode = mode;
+    await this.save();
+  }
+
+  getDefaultShell(): string | null {
+    return this.data.defaultShell;
+  }
+
+  async setDefaultShell(shellId: string | null): Promise<void> {
+    this.data.defaultShell = shellId;
     await this.save();
   }
 

--- a/src/preload.ts
+++ b/src/preload.ts
@@ -75,6 +75,10 @@ const api = {
     ipcRenderer.invoke('settings:removeRecentDir', dir),
   getPermissionMode: (): Promise<PermissionMode> =>
     ipcRenderer.invoke('settings:permissionMode'),
+  getDefaultShell: (): Promise<string | null> =>
+    ipcRenderer.invoke('settings:getDefaultShell'),
+  setDefaultShell: (shellId: string | null): Promise<void> =>
+    ipcRenderer.invoke('settings:setDefaultShell', shellId),
 
   // Hook config
   getHookConfig: (projectId?: string): Promise<RepoHookConfig> =>

--- a/src/renderer/App.tsx
+++ b/src/renderer/App.tsx
@@ -17,6 +17,7 @@ import WorktreeNameDialog from './components/WorktreeNameDialog';
 import WorktreeManagerDialog from './components/WorktreeManagerDialog';
 import WorktreeCloseDialog from './components/WorktreeCloseDialog';
 import HookManagerDialog from './components/HookManagerDialog';
+import SettingsDialog from './components/SettingsDialog';
 import { Dialog, DialogContent, DialogDescription, DialogFooter, DialogHeader, DialogTitle } from '@/components/ui/dialog';
 import { Button } from '@/components/ui/button';
 
@@ -54,19 +55,26 @@ export default function App() {
   });
   const [branch, setBranch] = useState<string | null>(null);
   const [showHookManager, setShowHookManager] = useState(false);
+  const [showSettings, setShowSettings] = useState(false);
+  const [defaultShell, setDefaultShell] = useState<string | null>(null);
   const [renamingTabId, setRenamingTabId] = useState<string | null>(null);
   const [availableShells, setAvailableShells] = useState<ShellOption[]>(
     () => getAllShellOptions(window.claudeTerminal?.platform ?? 'linux')
   );
+  const defaultShellRef = useRef(defaultShell);
+  defaultShellRef.current = defaultShell;
+  const availableShellsRef = useRef(availableShells);
+  availableShellsRef.current = availableShells;
   const [hookStatus, setHookStatus] = useState<{ hookName: string; status: 'running' | 'done' | 'failed'; error?: string } | null>(null);
   const hookDismissTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
   const [worktreeCloseConfirm, setWorktreeCloseConfirm] = useState<{
     tabId: string; worktreeName: string; clean: boolean; changesCount: number;
   } | null>(null);
 
-  // Fetch available shells (filter to installed ones)
+  // Fetch available shells (filter to installed ones) and default shell preference
   useEffect(() => {
     window.claudeTerminal.getAvailableShells().then(setAvailableShells).catch(() => {});
+    window.claudeTerminal.getDefaultShell().then(setDefaultShell).catch(() => {});
   }, []);
 
   // Filter tabs by active project
@@ -165,20 +173,32 @@ export default function App() {
 
   const handleNewShellTab = useCallback(async (shellType: string, afterTabId?: string) => {
     const tab = await window.claudeTerminal.createShellTab(shellType, afterTabId);
-    if (afterTabId) {
-      setTabs((prev) => {
-        const filtered = prev.filter(t => t.id !== tab.id);
+    setTabs((prev) => {
+      const filtered = prev.filter(t => t.id !== tab.id);
+      if (afterTabId) {
         const afterIdx = filtered.findIndex(t => t.id === afterTabId);
         if (afterIdx >= 0) {
           const next = [...filtered];
           next.splice(afterIdx + 1, 0, tab);
           return next;
         }
-        return [...filtered, tab];
-      });
-    }
+      }
+      return [...filtered, tab];
+    });
     setActiveTabId(tab.id);
     await window.claudeTerminal.switchTab(tab.id);
+  }, []);
+
+  const handleNewDefaultShellTab = useCallback(async (afterTabId?: string) => {
+    const shells = availableShellsRef.current;
+    const shellId = defaultShellRef.current ?? shells[0]?.id;
+    if (!shellId) return;
+    await handleNewShellTab(shellId, afterTabId);
+  }, [handleNewShellTab]);
+
+  const handleDefaultShellChange = useCallback(async (shellId: string) => {
+    setDefaultShell(shellId);
+    await window.claudeTerminal.setDefaultShell(shellId);
   }, []);
 
   const handleReorderTabs = useCallback((reordered: Tab[]) => {
@@ -442,7 +462,7 @@ export default function App() {
       addProject: handleAddProject,
       newTab: handleNewTabWithoutWorktree,
       newWorktreeTab: tryShowWorktreeDialog,
-      newShellTab: handleNewShellTab,
+      newDefaultShellTab: handleNewDefaultShellTab,
       closeTab: handleCloseTab,
       selectTab: handleSelectTab,
       selectProject: handleSelectProject,
@@ -470,7 +490,7 @@ export default function App() {
 
     window.addEventListener('keydown', handler);
     return () => window.removeEventListener('keydown', handler);
-  }, [appState, handleAddProject, handleNewTabWithoutWorktree, handleNewShellTab, handleSelectTab, handleSelectProject, handleCloseTab, tryShowWorktreeDialog]);
+  }, [appState, handleAddProject, handleNewTabWithoutWorktree, handleNewDefaultShellTab, handleSelectTab, handleSelectProject, handleCloseTab, tryShowWorktreeDialog]);
 
   const handleStartSession = useCallback(async (dir: string, mode: PermissionMode) => {
     const result = await window.claudeTerminal.startSession(dir, mode);
@@ -536,6 +556,7 @@ export default function App() {
           tabs={activeProjectTabs}
           activeTabId={activeTabId}
           renamingTabId={renamingTabId}
+          defaultShell={defaultShell}
           onSelectTab={handleSelectTab}
           onCloseTab={handleCloseTab}
           onRenameTab={handleRenameTab}
@@ -547,6 +568,7 @@ export default function App() {
           onRefreshTab={handleRefreshTab}
           onManageWorktrees={() => setShowWorktreeManager(true)}
           onManageHooks={() => setShowHookManager(true)}
+          onOpenSettings={() => setShowSettings(true)}
           remoteInfo={remoteInfo}
           onActivateRemote={handleActivateRemote}
           onDeactivateRemote={handleDeactivateRemote}
@@ -599,6 +621,12 @@ export default function App() {
       {showHookManager && (
         <HookManagerDialog onClose={() => setShowHookManager(false)} />
       )}
+      <SettingsDialog
+        open={showSettings}
+        onClose={() => setShowSettings(false)}
+        defaultShell={defaultShell}
+        onDefaultShellChange={handleDefaultShellChange}
+      />
       {showProjectSwitcher && (
         <ProjectSwitcherDialog
           projects={projects.map(p => ({

--- a/src/renderer/components/HamburgerMenu.tsx
+++ b/src/renderer/components/HamburgerMenu.tsx
@@ -1,13 +1,14 @@
-import { GitBranch, Zap, Menu } from 'lucide-react';
-import { DropdownMenu, DropdownMenuContent, DropdownMenuItem, DropdownMenuTrigger } from '@/components/ui/dropdown-menu';
+import { GitBranch, Zap, Menu, Settings } from 'lucide-react';
+import { DropdownMenu, DropdownMenuContent, DropdownMenuItem, DropdownMenuSeparator, DropdownMenuTrigger } from '@/components/ui/dropdown-menu';
 import { Button } from '@/components/ui/button';
 
 interface HamburgerMenuProps {
   onManageWorktrees: () => void;
   onManageHooks: () => void;
+  onOpenSettings: () => void;
 }
 
-export default function HamburgerMenu({ onManageWorktrees, onManageHooks }: HamburgerMenuProps) {
+export default function HamburgerMenu({ onManageWorktrees, onManageHooks, onOpenSettings }: HamburgerMenuProps) {
   return (
     <DropdownMenu>
       <DropdownMenuTrigger asChild>
@@ -23,6 +24,11 @@ export default function HamburgerMenu({ onManageWorktrees, onManageHooks }: Hamb
         <DropdownMenuItem onClick={onManageHooks}>
           <Zap size={14} />
           <span>Manage hooks</span>
+        </DropdownMenuItem>
+        <DropdownMenuSeparator />
+        <DropdownMenuItem onClick={onOpenSettings}>
+          <Settings size={14} />
+          <span>Settings</span>
         </DropdownMenuItem>
       </DropdownMenuContent>
     </DropdownMenu>

--- a/src/renderer/components/SettingsDialog.tsx
+++ b/src/renderer/components/SettingsDialog.tsx
@@ -1,0 +1,50 @@
+import { useState } from 'react';
+import { Dialog, DialogContent, DialogHeader, DialogTitle } from '@/components/ui/dialog';
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select';
+import { useShellOptions } from '../shell-context';
+
+interface SettingsDialogProps {
+  open: boolean;
+  onClose: () => void;
+  defaultShell: string | null;
+  onDefaultShellChange: (shellId: string) => void;
+}
+
+export default function SettingsDialog({ open, onClose, defaultShell, onDefaultShellChange }: SettingsDialogProps) {
+  const shellOptions = useShellOptions();
+
+  // Resolve the effective value: saved preference, or first available shell
+  const effectiveShell = defaultShell && shellOptions.some(s => s.id === defaultShell)
+    ? defaultShell
+    : shellOptions[0]?.id ?? '';
+
+  return (
+    <Dialog open={open} onOpenChange={(v) => { if (!v) onClose(); }}>
+      <DialogContent className="max-w-md">
+        <DialogHeader>
+          <DialogTitle>Settings</DialogTitle>
+        </DialogHeader>
+        <div className="space-y-4 py-2">
+          <div className="flex items-center justify-between gap-4">
+            <div>
+              <div className="text-sm font-medium">Default terminal</div>
+              <div className="text-xs text-muted-foreground">Opened with Ctrl+`</div>
+            </div>
+            <Select value={effectiveShell} onValueChange={onDefaultShellChange}>
+              <SelectTrigger className="w-[160px]">
+                <SelectValue />
+              </SelectTrigger>
+              <SelectContent>
+                {shellOptions.map((shell) => (
+                  <SelectItem key={shell.id} value={shell.id}>
+                    {shell.label}
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+          </div>
+        </div>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/src/renderer/components/StatusBar.tsx
+++ b/src/renderer/components/StatusBar.tsx
@@ -1,7 +1,6 @@
 import React from 'react';
 import { cn } from '@/lib/utils';
 import type { Tab, TabStatus } from '../../shared/types';
-import { useShellOptions } from '../shell-context';
 import TabIndicator from './TabIndicator';
 
 const STATUS_ORDER: { status: TabStatus; label: string }[] = [
@@ -29,13 +28,6 @@ interface StatusBarProps {
 }
 
 const StatusBar = React.memo(function StatusBar({ tabs, hookStatus }: StatusBarProps) {
-  const shellOptions = useShellOptions();
-  const isWindows = window.claudeTerminal?.platform === 'win32';
-  const shellHint = shellOptions.length >= 2 && isWindows
-    ? `Ctrl+Shift+P ${shellOptions[0].label} | Ctrl+L ${shellOptions[1].label}`
-    : shellOptions.length >= 1
-    ? `Ctrl+Shift+P ${shellOptions[0].label}`
-    : '';
   const counts = new Map<TabStatus, number>();
   for (const tab of tabs) {
     counts.set(tab.status, (counts.get(tab.status) ?? 0) + 1);
@@ -61,7 +53,7 @@ const StatusBar = React.memo(function StatusBar({ tabs, hookStatus }: StatusBarP
         </span>
       )}
       <span className="ml-auto overflow-hidden whitespace-nowrap text-ellipsis min-w-0">
-        Ctrl+T Claude | Ctrl+W Worktree | Ctrl+P Projects{shellHint ? ` | ${shellHint}` : ''} | Ctrl+F4 close | Ctrl+Tab switch | F2 rename
+        Ctrl+T Claude | Ctrl+W Worktree | Ctrl+` Terminal | Ctrl+P Projects | Ctrl+F4 close | Ctrl+Tab switch | F2 rename
       </span>
     </div>
   );

--- a/src/renderer/components/TabBar.tsx
+++ b/src/renderer/components/TabBar.tsx
@@ -12,6 +12,7 @@ interface TabBarProps {
   tabs: TabType[];
   activeTabId: string | null;
   renamingTabId: string | null;
+  defaultShell: string | null;
   onSelectTab: (tabId: string) => void;
   onCloseTab: (tabId: string) => void;
   onRenameTab: (tabId: string, name: string) => void;
@@ -23,19 +24,17 @@ interface TabBarProps {
   onRefreshTab: (tabId: string) => void;
   onManageWorktrees: () => void;
   onManageHooks: () => void;
+  onOpenSettings: () => void;
   remoteInfo: RemoteAccessInfo;
   onActivateRemote: () => void;
   onDeactivateRemote: () => void;
 }
 
-// Shortcut labels — Ctrl+L (second shell) only on Windows to avoid terminal clear-screen conflict
-const isWindows = window.claudeTerminal?.platform === 'win32';
-const shellShortcuts = isWindows ? ['Ctrl+Shift+P', 'Ctrl+L'] : ['Ctrl+Shift+P'];
-
 export default function TabBar({
   tabs,
   activeTabId,
   renamingTabId,
+  defaultShell,
   onSelectTab,
   onCloseTab,
   onRenameTab,
@@ -47,6 +46,7 @@ export default function TabBar({
   onRefreshTab,
   onManageWorktrees,
   onManageHooks,
+  onOpenSettings,
   remoteInfo,
   onActivateRemote,
   onDeactivateRemote,
@@ -138,14 +138,17 @@ export default function TabBar({
             <span className="ml-auto text-[11px] text-muted-foreground">Ctrl+W</span>
           </DropdownMenuItem>
           {shellOptions.length > 0 && <DropdownMenuSeparator />}
-          {shellOptions.map((shell, i) => (
-            <DropdownMenuItem key={shell.id} onClick={() => onNewShellTab(shell.id, activeTabId ?? undefined)}>
-              <span>{shell.label}</span>
-              {i < shellShortcuts.length && (
-                <span className="ml-auto text-[11px] text-muted-foreground">{shellShortcuts[i]}</span>
-              )}
-            </DropdownMenuItem>
-          ))}
+          {shellOptions.map((shell) => {
+            const isDefault = defaultShell ? shell.id === defaultShell : shell.id === shellOptions[0]?.id;
+            return (
+              <DropdownMenuItem key={shell.id} onClick={() => onNewShellTab(shell.id, activeTabId ?? undefined)}>
+                <span>{shell.label}</span>
+                {isDefault && (
+                  <span className="ml-auto text-[11px] text-muted-foreground">Ctrl+`</span>
+                )}
+              </DropdownMenuItem>
+            );
+          })}
         </DropdownMenuContent>
       </DropdownMenu>
       <div className="flex items-center ml-auto [-webkit-app-region:no-drag]">
@@ -155,7 +158,7 @@ export default function TabBar({
           onActivate={onActivateRemote}
           onDeactivate={onDeactivateRemote}
         />
-        <HamburgerMenu onManageWorktrees={onManageWorktrees} onManageHooks={onManageHooks} />
+        <HamburgerMenu onManageWorktrees={onManageWorktrees} onManageHooks={onManageHooks} onOpenSettings={onOpenSettings} />
       </div>
     </div>
   );

--- a/src/renderer/keybindings.ts
+++ b/src/renderer/keybindings.ts
@@ -8,8 +8,6 @@
  * To add a new keybinding: add one entry to the array below. Done.
  */
 
-import { getAllShellOptions } from '@shared/platform';
-
 export interface KeybindingContext {
   activeTabId: () => string | null;
   tabs: () => { id: string }[];
@@ -18,7 +16,7 @@ export interface KeybindingContext {
   addProject: () => void;
   newTab: () => void;
   newWorktreeTab: () => void;
-  newShellTab: (shellType: string, afterTabId?: string) => void;
+  newDefaultShellTab: (afterTabId?: string) => void;
   closeTab: (tabId: string) => void;
   selectTab: (tabId: string) => void;
   selectProject: (projectId: string) => void;
@@ -52,31 +50,12 @@ function cycleProject(ctx: KeybindingContext, direction: 1 | -1) {
   ctx.selectProject(projects[next].id);
 }
 
-// Shell keybindings are platform-dependent.
-// Ctrl+L conflicts with terminal clear-screen on all platforms, so we only
-// bind it on Windows (where the WSL shortcut was already established).
-const platform = window.claudeTerminal?.platform ?? 'linux';
-const shellOptions = getAllShellOptions(platform);
-const shellKeybindings: Keybinding[] = [];
-if (shellOptions.length >= 1) {
-  shellKeybindings.push({
-    mod: 'ctrl+shift', key: 'P',
-    action: (ctx) => ctx.newShellTab(shellOptions[0].id, ctx.activeTabId() ?? undefined),
-  });
-}
-if (shellOptions.length >= 2 && platform === 'win32') {
-  shellKeybindings.push({
-    mod: 'ctrl', key: 'l',
-    action: (ctx) => ctx.newShellTab(shellOptions[1].id, ctx.activeTabId() ?? undefined),
-  });
-}
-
 export const keybindings: Keybinding[] = [
   { mod: 'ctrl',       key: 'n',          action: (ctx) => ctx.addProject() },
   { mod: 'ctrl',       key: 't',          action: (ctx) => ctx.newTab() },
   { mod: 'ctrl',       key: 'w',          action: (ctx) => ctx.newWorktreeTab() },
   { mod: 'ctrl',       key: 'p',          action: (ctx) => ctx.openProjectSwitcher() },
-  ...shellKeybindings,
+  { mod: 'ctrl',       key: '`',          action: (ctx) => ctx.newDefaultShellTab(ctx.activeTabId() ?? undefined) },
   { mod: 'ctrl',       key: 'F4',         action: (ctx) => { const id = ctx.activeTabId(); if (id) ctx.closeTab(id); } },
   { mod: 'ctrl',       key: 'Tab',        action: (ctx) => cycleTab(ctx, 1) },
   { mod: 'ctrl+shift', key: 'Tab',        action: (ctx) => cycleTab(ctx, -1) },

--- a/src/web-client/main.tsx
+++ b/src/web-client/main.tsx
@@ -363,6 +363,7 @@ function RemoteApp({ initialTabs, initialActiveTabId, initialTermSizes, onDiscon
             tabs={tabs}
             activeTabId={activeTabId}
             renamingTabId={null}
+            defaultShell={null}
             onSelectTab={handleSelectTab}
             onCloseTab={noop}
             onRenameTab={handleRenameTab}
@@ -374,6 +375,7 @@ function RemoteApp({ initialTabs, initialActiveTabId, initialTermSizes, onDiscon
             onRefreshTab={noop}
             onManageWorktrees={noop}
             onManageHooks={noop}
+            onOpenSettings={noop}
             remoteInfo={remoteInfo}
             onActivateRemote={noop}
             onDeactivateRemote={noop}

--- a/src/web-client/ws-bridge.ts
+++ b/src/web-client/ws-bridge.ts
@@ -313,6 +313,8 @@ export class WebSocketBridge {
       getRecentDirs: async (): Promise<string[]> => [],
       removeRecentDir: async (): Promise<void> => {},
       getPermissionMode: async () => 'default' as const,
+      getDefaultShell: async () => null,
+      setDefaultShell: async () => {},
 
       // Hook config (stubs — not available remotely)
       getHookConfig: async () => ({ hooks: {} }),

--- a/tests/main/ipc-handlers.test.ts
+++ b/tests/main/ipc-handlers.test.ts
@@ -188,7 +188,7 @@ describe('registerIpcHandlers', () => {
       'tab:create', 'tab:createWithWorktree', 'tab:createShell', 'tab:close', 'tab:switch', 'tab:rename', 'tab:getAll', 'tab:getActiveId',
       'worktree:create', 'worktree:currentBranch', 'worktree:listDetails', 'worktree:remove', 'worktree:checkStatus',
       'hookConfig:load', 'hookConfig:save',
-      'settings:recentDirs', 'settings:removeRecentDir', 'settings:permissionMode',
+      'settings:recentDirs', 'settings:removeRecentDir', 'settings:permissionMode', 'settings:getDefaultShell', 'settings:setDefaultShell',
       'dialog:selectDirectory', 'cli:getStartDir',
       'remote:activate', 'remote:deactivate', 'remote:getInfo',
       'instance:getHue',


### PR DESCRIPTION
## Summary
- Add a Settings dialog (hamburger menu > Settings) with a default terminal picker dropdown
- Replace platform-specific shell keybindings (Ctrl+Shift+P, Ctrl+L) with a single **Ctrl+`** shortcut that launches the user's configured default terminal
- Shell detection still runs at startup to filter to installed shells; the setting persists across sessions
- Fix shell tab not appearing immediately when created as the first tab (sync state update)

## Test plan
- [ ] Open app, press Ctrl+` — default terminal opens immediately (no rendering glitch)
- [ ] Open Settings from hamburger menu, change default terminal, press Ctrl+` — new default is used
- [ ] Restart app — default terminal preference persists
- [ ] Verify "+" dropdown shows Ctrl+` hint next to the default shell
- [ ] Verify status bar shows updated shortcut docs
- [ ] Run `pnpm run test` — all 166 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)